### PR TITLE
More readable share URLs

### DIFF
--- a/graphtool.js
+++ b/graphtool.js
@@ -964,7 +964,7 @@ function addPhonesToUrl() {
     let title = baseTitle, url = baseURL,
         names = activePhones.map(p => p.fileName);
     if (names.length) {
-        url += "?share=" + encodeURI(names.join());
+        url += "?share=" + encodeURI(names.join().replaceAll(" ","_"));
         title = names.join(", ") + " - " + title;
     }
     window.top.history.replaceState("", title, url);
@@ -1411,7 +1411,7 @@ d3.json(typeof PHONE_BOOK !== "undefined" ? PHONE_BOOK
             par = "?share=";
         baseURL = url.split("?").shift();
         if (url.includes(par)) {
-            initReq = decodeURI(url.split(par).pop()).split(",");
+            initReq = decodeURI(url.replaceAll("_"," ").split(par).pop()).split(",");
         }
     }
     let isInit = initReq ? f => initReq.indexOf(f) !== -1


### PR DESCRIPTION
Makes share URLs a bit more readable by replacing spaces in phone file names (e.g. %20) with underscores, then decodes them back to spaces when initializing.